### PR TITLE
URI encode according to AWS signature calculations documentation

### DIFF
--- a/aws-sign-web.js
+++ b/aws-sign-web.js
@@ -258,9 +258,9 @@
      * Reference: http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
      */
     function uriEncode(input, encodeSlash) {
-        const result = [];
-        for (let i = 0; i < input.length; i++) {
-            const ch = input.charAt(i);
+        var result = [];
+        for (var i = 0; i < input.length; i++) {
+            var ch = input.charAt(i);
             if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '_' || ch === '-' || ch === '~' || ch === '.') {
                 result.push(ch);
             } else if (ch === '/') {
@@ -277,7 +277,7 @@
     function toHexUTF8(ch) {
         const utf8Sequence = utf8.encode(ch);
         const encodedChar = [];
-        for (let i = 0; i < utf8Sequence.length; i++) {
+        for (var i = 0; i < utf8Sequence.length; i++) {
             encodedChar.push("%");
             encodedChar.push(utf8Sequence[i].charCodeAt(0).toString(16).toUpperCase());
         }

--- a/aws-sign-web.js
+++ b/aws-sign-web.js
@@ -269,7 +269,7 @@
                 result.push(toHexUTF8(ch));
             }
         }
-        return result.join();
+        return result.join("");
     }
 
     const utf8 = require('utf8');
@@ -279,9 +279,9 @@
         const encodedChar = [];
         for (let i = 0; i < utf8Sequence.length; i++) {
             encodedChar.push("%");
-            encodedChar.push(utf8Sequence[i].charCodeAt(0).toString(16));
+            encodedChar.push(utf8Sequence[i].charCodeAt(0).toString(16).toUpperCase());
         }
-        return encodedChar.join();
+        return encodedChar.join("");
     }
 
     /**

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cryptojslib": "~3.1.2"
+    "cryptojslib": "~3.1.2",
+    "utf8": "^2.1.2"
   },
   "homepage": "https://github.com/danieljoos/aws-sign-web#readme",
   "version": "1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sign-web",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Plain JavaScript AWS Signature v4 for use within Web Browsers",
   "keywords": [
     "aws",
@@ -29,6 +29,7 @@
     "gulp-uglify": "^1.5.3"
   },
   "dependencies": {
-    "crypto-js": "^3.1.6"
+    "crypto-js": "^3.1.6",
+    "utf8": "^2.1.2"
   }
 }


### PR DESCRIPTION
URI encode every byte. UriEncode() must enforce the following rules:

    URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.

    The space character is a reserved character and must be encoded as "%20" (and not as "+").

    Each URI encoded byte is formed by a '%' and the two-digit hexadecimal value of the byte.

    Letters in the hexadecimal value must be uppercase, for example "%1A".

    Encode the forward slash character, '/', everywhere except in the object key name. For example, if the object key name is photos/Jan/sample.jpg, the forward slash in the key name is not encoded.

reference: http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html