### PR TITLE
Extract query parameter values which contain an 'equals' character.

### DIFF
--- a/aws-sign-web.js
+++ b/aws-sign-web.js
@@ -248,7 +248,7 @@
 
         function extractQueryParams(search) {
             return /^\??(.*)$/.exec(search)[1].split('&').reduce(function (result, arg) {
-                arg = /^(.+)=(.*)$/.exec(arg);
+                arg = /^(.+?)=(.*)$/.exec(arg);
                 if (arg) {
                     var paramKey = decodeURI(arg[1]);
                     result[paramKey] = (


### PR DESCRIPTION
The current regex does not correct handle this case:

Input: "nextToken=base64EncodedToken==&key=value"
Expected:
 - "nextToken" => ["base64EncodedToken=="]
 - "key" => ["value"]
Actual:
 - "nextToken=base64EncodedToken==" => [""]
 - "key" => ["value"]

The updated regex correctly handles this use case.