### PR TITLE
Encode query param values correctly when they contain URI reserved chars.

### DIFF
--- a/aws-sign-web.js
+++ b/aws-sign-web.js
@@ -145,7 +145,8 @@
                 // Canonical Query String:
             flatten(Object.keys(ws.uri.queryParams).sort().map(function (key) {
                 return ws.uri.queryParams[key].sort().map(function(val) {
-                    return encodeURIComponent(key) + '=' + encodeURIComponent(val);
+                    // Query-param values must be percent-encoded for signing.
+                    return encodeURIComponent(key) + '=' + uriEncode(val);
                 })
             })).join('&') + '\n' +
                 // Canonical Headers:

--- a/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-utf8/get-utf8.authz
+++ b/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-utf8/get-utf8.authz
@@ -1,1 +1,1 @@
-AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85
+AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=697b34846207a3f72246f99d74ae1ee4fe54f44bb06730c58a0d339eb079596d


### PR DESCRIPTION
As per the [SigV4 signing spec](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html):

URI-encode each parameter name and value according to the following rules:
 1. Do not URI-encode any of the unreserved characters that RFC 3986 defines: A-Z, a-z, 0-9, hyphen ( - ), underscore ( _ ), period ( . ), and tilde ( ~ ).
 2. Percent-encode all other characters with %XY, where X and Y are hexadecimal characters (0-9 and uppercase A-F). For example, the space character must be encoded as %20 (not using '+', as some encoding schemes do) and extended UTF-8 characters must be in the form %XY%ZA%BC.
 3. Double-encode any equals ( = ) characters in parameter values.

This change correctly encodes the query parameter value as required.

Related issue: https://github.com/danieljoos/aws-sign-web/issues/9