### PR TITLE
Add handling for query params from both URI and request params

### DIFF
--- a/aws-sign-web.js
+++ b/aws-sign-web.js
@@ -144,9 +144,16 @@
             }).join('/') + '\n' +
                 // Canonical Query String:
             flatten(Object.keys(ws.uri.queryParams).sort().map(function (key) {
-                return ws.uri.queryParams[key].sort().map(function(val) {
+                var queryParamsForKey = ws.uri.queryParams[key];
+                if (Array.isArray(queryParamsForKey)) {
+                    // Sort is going to mutate this array, which we don't necessarily own, so we make a defensive copy
+                    queryParamsForKey = [].slice.call(queryParamsForKey);
+                } else {
+                    queryParamsForKey = [queryParamsForKey];
+                }
+                return queryParamsForKey.sort().map(function(val) {
                     return encodeURIComponent(key) + '=' + encodeURIComponent(val);
-                })
+                });
             })).join('&') + '\n' +
                 // Canonical Headers:
             ws.sortedHeaderKeys.map(function (key) {

--- a/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.authz
+++ b/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.authz
@@ -1,0 +1,1 @@
+AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500

--- a/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.params
+++ b/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.params
@@ -1,0 +1,1 @@
+{ "Param2": "value2" }

--- a/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.req
+++ b/test/aws-sig-v4-test-suite/aws-sig-v4-test-suite/get-vanilla-query-uri-config/get-vanilla-query-uri-config.req
@@ -1,0 +1,3 @@
+GET /?Param1=value1 HTTP/1.1
+Host:example.amazonaws.com
+X-Amz-Date:20150830T123600Z


### PR DESCRIPTION
Including non-array params in the signed request object was causing
the following error:

> TypeError: ws.uri.queryParams[key].sort is not a function

This fixes that and adds a test to make sure it's fixed. As I am
not familiar with the tool used to generate test data, I cloned and
modified existing test data.

issue: https://github.com/danieljoos/aws-sign-web/issues/20