### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sign-web",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Plain JavaScript AWS Signature v4 for use within Web Browsers",
   "keywords": [
     "aws",


### PR DESCRIPTION
I forgot to do this in the previous commit. I believe we have to
bump the version so people are actually able to get the change.